### PR TITLE
feat: add authenticated public REST API for site-visit data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ PIPEDRIVE_API_TOKEN=your_pipedrive_api_token
 PIPEDRIVE_BASE_URL=https://api.pipedrive.com/v1
 PIPEDRIVE_SUBMIT_MODE=mock
 
+# Bearer token used by the public read-only API consumed by the Pipedrive MCP server.
+# Generate with: openssl rand -hex 32
+PUBLIC_API_TOKEN=
+
 # Slack Configuration (optional)
 SLACK_BOT_TOKEN=xoxb-your-slack-bot-token
 SLACK_CHANNEL=#your-channel

--- a/README.md
+++ b/README.md
@@ -270,6 +270,30 @@ export const generateQRId = (): string => {
 
 ## API Reference
 
+## Public API (for MCP / external consumers)
+
+The public API v1 is read-only, covers site visits only, and is consumed by the Pipedrive MCP server maintained in a separate repository.
+
+Authenticate requests with the configured bearer token:
+
+```http
+Authorization: Bearer $PUBLIC_API_TOKEN
+```
+
+Fetch site visits:
+
+```bash
+curl -H "Authorization: Bearer $PUBLIC_API_TOKEN" \
+  "http://localhost:3000/api/public/site-visits"
+```
+
+Fetch monthly site-visit frequency:
+
+```bash
+curl -H "Authorization: Bearer $PUBLIC_API_TOKEN" \
+  "http://localhost:3000/api/public/site-visits/monthly-frequency"
+```
+
 ### Core API Endpoints
 
 #### 1. `/api/submit` (POST)
@@ -1035,4 +1059,3 @@ The application has successfully completed Phase 1 of the modularization plan:
 ---
 
 This comprehensive documentation provides a complete overview of the Sales Helper App's architecture, implementation details, and operational characteristics. The application demonstrates a well-structured, mobile-first approach to sales workflow management with robust testing, caching, and deployment practices, enhanced by manual cache refresh capabilities for improved data synchronization.
-

--- a/app/api/public/site-visits/monthly-frequency/route.ts
+++ b/app/api/public/site-visits/monthly-frequency/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { and, asc, count, eq, gte, lt } from 'drizzle-orm';
+import { z } from 'zod';
+import { requireBearer } from '@/lib/auth/public-api-auth';
+import { createStandardConnection, sql } from '@/lib/database/connection-standard';
+import { siteVisits } from '@/lib/database/schema';
+import { logError } from '@/lib/log';
+
+export const dynamic = 'force-dynamic';
+
+const MonthSchema = z.string().regex(/^\d{4}-(0[1-9]|1[0-2])$/, 'Expected YYYY-MM');
+const SalespersonSchema = z.enum(['James', 'Luyanda', 'Stefan']);
+
+const QuerySchema = z.object({
+  from: MonthSchema.optional(),
+  to: MonthSchema.optional(),
+  salesperson: SalespersonSchema.optional(),
+});
+
+const addMonths = (date: Date, months: number) =>
+  new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + months, 1));
+
+const currentMonthStart = () => {
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
+};
+
+const formatMonth = (date: Date) => {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  return `${year}-${month}`;
+};
+
+const parseMonthStart = (month: string) => {
+  const [year, monthNumber] = month.split('-').map(Number);
+  return new Date(Date.UTC(year, monthNumber - 1, 1));
+};
+
+const formatMonthValue = (value: Date | string) => {
+  if (value instanceof Date) {
+    return formatMonth(value);
+  }
+
+  const monthMatch = value.match(/^\d{4}-\d{2}/);
+  if (monthMatch) {
+    return monthMatch[0];
+  }
+
+  return formatMonth(new Date(value));
+};
+
+export async function GET(req: NextRequest) {
+  const unauthorized = requireBearer(req);
+  if (unauthorized) {
+    return unauthorized;
+  }
+
+  const { searchParams } = new URL(req.url);
+  const parsedQuery = QuerySchema.safeParse({
+    from: searchParams.get('from') ?? undefined,
+    to: searchParams.get('to') ?? undefined,
+    salesperson: searchParams.get('salesperson') ?? undefined,
+  });
+
+  if (!parsedQuery.success) {
+    return NextResponse.json(
+      { ok: false, error: parsedQuery.error.issues.map((issue) => issue.message) },
+      { status: 400 }
+    );
+  }
+
+  const defaultTo = currentMonthStart();
+  const defaultFrom = addMonths(defaultTo, -11);
+  const fromMonth = parsedQuery.data.from ?? formatMonth(defaultFrom);
+  const toMonth = parsedQuery.data.to ?? formatMonth(defaultTo);
+
+  if (fromMonth > toMonth) {
+    return NextResponse.json(
+      { ok: false, error: 'from must be before or equal to to' },
+      { status: 400 }
+    );
+  }
+
+  const fromDate = parseMonthStart(fromMonth);
+  const toExclusiveDate = addMonths(parseMonthStart(toMonth), 1);
+  const monthExpression = sql<Date>`date_trunc('month', ${siteVisits.date})`;
+  const filters = [
+    gte(siteVisits.date, fromDate),
+    lt(siteVisits.date, toExclusiveDate),
+  ];
+
+  if (parsedQuery.data.salesperson) {
+    filters.push(eq(siteVisits.salesperson, parsedQuery.data.salesperson));
+  }
+
+  try {
+    const { db } = createStandardConnection();
+    const rows = await db
+      .select({
+        month: monthExpression,
+        salesperson: siteVisits.salesperson,
+        visit_count: count(siteVisits.id),
+      })
+      .from(siteVisits)
+      .where(and(...filters))
+      .groupBy(monthExpression, siteVisits.salesperson)
+      .orderBy(asc(monthExpression), asc(siteVisits.salesperson));
+
+    return NextResponse.json({
+      ok: true,
+      data: rows.map((row) => ({
+        month: formatMonthValue(row.month),
+        salesperson: row.salesperson,
+        visit_count: Number(row.visit_count),
+      })),
+    });
+  } catch (error) {
+    logError('Failed to fetch monthly site visit frequency', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    return NextResponse.json(
+      { ok: false, error: 'Internal error' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/public/site-visits/route.ts
+++ b/app/api/public/site-visits/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { and, desc, eq, gte, lte, type SQL } from 'drizzle-orm';
+import { z } from 'zod';
+import { requireBearer } from '@/lib/auth/public-api-auth';
+import { createStandardConnection } from '@/lib/database/connection-standard';
+import { siteVisits } from '@/lib/database/schema';
+import { generateCorrelationId, logError } from '@/lib/log';
+
+const yyyyMmDdPattern = /^\d{4}-\d{2}-\d{2}$/;
+
+const isValidDateString = (value: string) => {
+  if (!yyyyMmDdPattern.test(value)) {
+    return false;
+  }
+
+  const [year, month, day] = value.split('-').map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  );
+};
+
+const optionalDateParam = z
+  .string()
+  .refine(isValidDateString, 'Expected date in YYYY-MM-DD format')
+  .optional();
+
+const QuerySchema = z.object({
+  from: optionalDateParam,
+  to: optionalDateParam,
+  salesperson: z.enum(['James', 'Luyanda', 'Stefan']).optional(),
+  limit: z
+    .preprocess(
+      (value) => (value === undefined || value === '' ? undefined : Number(value)),
+      z.number().int().min(1).max(1000).default(500)
+    ),
+});
+
+const startOfDayUtc = (value: string) => new Date(`${value}T00:00:00.000Z`);
+const endOfDayUtc = (value: string) => new Date(`${value}T23:59:59.999Z`);
+
+export async function GET(req: NextRequest) {
+  const authResponse = requireBearer(req);
+  if (authResponse) {
+    return authResponse;
+  }
+
+  const correlationId = generateCorrelationId();
+
+  try {
+    const { searchParams } = new URL(req.url);
+    const query = QuerySchema.parse({
+      from: searchParams.get('from') ?? undefined,
+      to: searchParams.get('to') ?? undefined,
+      salesperson: searchParams.get('salesperson') ?? undefined,
+      limit: searchParams.get('limit') ?? undefined,
+    });
+
+    const filters: SQL[] = [];
+
+    if (query.from) {
+      filters.push(gte(siteVisits.date, startOfDayUtc(query.from)));
+    }
+
+    if (query.to) {
+      filters.push(lte(siteVisits.date, endOfDayUtc(query.to)));
+    }
+
+    if (query.salesperson) {
+      filters.push(eq(siteVisits.salesperson, query.salesperson));
+    }
+
+    const { db } = createStandardConnection();
+    const selectedFields = {
+      id: siteVisits.id,
+      date: siteVisits.date,
+      salesperson: siteVisits.salesperson,
+      plannedMines: siteVisits.plannedMines,
+      mainPurpose: siteVisits.mainPurpose,
+      comments: siteVisits.comments,
+    };
+
+    const rows = filters.length > 0
+      ? await db
+          .select(selectedFields)
+          .from(siteVisits)
+          .where(and(...filters))
+          .orderBy(desc(siteVisits.date))
+          .limit(query.limit)
+      : await db
+          .select(selectedFields)
+          .from(siteVisits)
+          .orderBy(desc(siteVisits.date))
+          .limit(query.limit);
+
+    const data = rows.map((visit) => ({
+      id: visit.id,
+      date: visit.date,
+      salesperson: visit.salesperson,
+      planned_mines: visit.plannedMines,
+      main_purpose: visit.mainPurpose,
+      comments: visit.comments,
+    }));
+
+    return NextResponse.json({ ok: true, data, count: data.length });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { ok: false, error: error.issues },
+        { status: 400 }
+      );
+    }
+
+    logError('Public site visits fetch failed', {
+      correlationId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    return NextResponse.json(
+      { ok: false, error: 'Internal error' },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/auth/public-api-auth.ts
+++ b/lib/auth/public-api-auth.ts
@@ -1,0 +1,60 @@
+import { timingSafeEqual } from 'crypto';
+import { NextRequest, NextResponse } from 'next/server';
+import { generateCorrelationId, logError, logWarn } from '@/lib/log';
+
+const unauthorizedResponse = () =>
+  NextResponse.json({ ok: false, error: 'Unauthorized' }, { status: 401 });
+
+const misconfiguredResponse = () =>
+  NextResponse.json({ ok: false, error: 'Server misconfigured' }, { status: 500 });
+
+const safeTokenEquals = (providedToken: string, expectedToken: string): boolean => {
+  const expected = Buffer.from(expectedToken);
+  const provided = Buffer.from(providedToken);
+
+  if (provided.length === expected.length) {
+    return timingSafeEqual(provided, expected);
+  }
+
+  const normalizedProvided = Buffer.alloc(expected.length);
+  provided.copy(normalizedProvided, 0, 0, Math.min(provided.length, expected.length));
+  timingSafeEqual(normalizedProvided, expected);
+  return false;
+};
+
+const rejectUnauthorized = (reason: string) => {
+  const correlationId = generateCorrelationId();
+  logWarn('Public API authorization failed', { correlationId, reason });
+  return unauthorizedResponse();
+};
+
+export function requireBearer(req: NextRequest): NextResponse | null {
+  const expectedToken = process.env.PUBLIC_API_TOKEN;
+
+  if (!expectedToken) {
+    if (process.env.NODE_ENV === 'production') {
+      logError('PUBLIC_API_TOKEN is not configured for public API authentication');
+      return misconfiguredResponse();
+    }
+
+    return rejectUnauthorized('token_not_configured');
+  }
+
+  const authorization = req.headers.get('authorization');
+
+  if (!authorization) {
+    return rejectUnauthorized('missing_authorization_header');
+  }
+
+  if (!authorization.startsWith('Bearer ')) {
+    return rejectUnauthorized('invalid_authorization_scheme');
+  }
+
+  const providedToken = authorization.slice('Bearer '.length);
+
+  if (!providedToken || !safeTokenEquals(providedToken, expectedToken)) {
+    return rejectUnauthorized('invalid_token');
+  }
+
+  return null;
+}

--- a/tests/unit/public-api-auth.test.ts
+++ b/tests/unit/public-api-auth.test.ts
@@ -1,0 +1,104 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { requireBearer } from '@/lib/auth/public-api-auth';
+import { generateCorrelationId, logError, logWarn } from '@/lib/log';
+
+vi.mock('@/lib/log', () => ({
+  generateCorrelationId: vi.fn(() => 'test-correlation-id'),
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+}));
+
+const createRequest = (authorization?: string) => {
+  const headers = new Headers();
+
+  if (authorization !== undefined) {
+    headers.set('Authorization', authorization);
+  }
+
+  return new NextRequest('http://localhost/api/public/site-visits', { headers });
+};
+
+const parseResponse = async (response: Response) => ({
+  status: response.status,
+  body: await response.json(),
+});
+
+describe('requireBearer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    vi.stubEnv('PUBLIC_API_TOKEN', 'expected-token');
+    vi.mocked(generateCorrelationId).mockReturnValue('test-correlation-id');
+  });
+
+  it('rejects requests with a missing authorization header', async () => {
+    const response = requireBearer(createRequest());
+
+    expect(response).not.toBeNull();
+    await expect(parseResponse(response!)).resolves.toEqual({
+      status: 401,
+      body: { ok: false, error: 'Unauthorized' },
+    });
+    expect(logWarn).toHaveBeenCalledWith('Public API authorization failed', {
+      correlationId: 'test-correlation-id',
+      reason: 'missing_authorization_header',
+    });
+    expect(JSON.stringify(vi.mocked(logWarn).mock.calls)).not.toContain('expected-token');
+  });
+
+  it('rejects requests with the wrong authorization scheme', async () => {
+    const response = requireBearer(createRequest('Basic expected-token'));
+
+    expect(response).not.toBeNull();
+    await expect(parseResponse(response!)).resolves.toEqual({
+      status: 401,
+      body: { ok: false, error: 'Unauthorized' },
+    });
+    expect(logWarn).toHaveBeenCalledWith('Public API authorization failed', {
+      correlationId: 'test-correlation-id',
+      reason: 'invalid_authorization_scheme',
+    });
+    expect(JSON.stringify(vi.mocked(logWarn).mock.calls)).not.toContain('Basic expected-token');
+  });
+
+  it('rejects requests with the wrong bearer token', async () => {
+    const response = requireBearer(createRequest('Bearer wrong-token'));
+
+    expect(response).not.toBeNull();
+    await expect(parseResponse(response!)).resolves.toEqual({
+      status: 401,
+      body: { ok: false, error: 'Unauthorized' },
+    });
+    expect(logWarn).toHaveBeenCalledWith('Public API authorization failed', {
+      correlationId: 'test-correlation-id',
+      reason: 'invalid_token',
+    });
+    expect(JSON.stringify(vi.mocked(logWarn).mock.calls)).not.toContain('wrong-token');
+  });
+
+  it('accepts requests with the correct bearer token', () => {
+    const response = requireBearer(createRequest('Bearer expected-token'));
+
+    expect(response).toBeNull();
+    expect(logWarn).not.toHaveBeenCalled();
+    expect(logError).not.toHaveBeenCalled();
+  });
+
+  it('returns server misconfigured when the token is unset in production', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('PUBLIC_API_TOKEN', '');
+
+    const response = requireBearer(createRequest('Bearer expected-token'));
+
+    expect(response).not.toBeNull();
+    await expect(parseResponse(response!)).resolves.toEqual({
+      status: 500,
+      body: { ok: false, error: 'Server misconfigured' },
+    });
+    expect(logError).toHaveBeenCalledWith(
+      'PUBLIC_API_TOKEN is not configured for public API authentication'
+    );
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/public-site-visits-api.test.ts
+++ b/tests/unit/public-site-visits-api.test.ts
@@ -1,0 +1,348 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET as getPublicSiteVisits } from '../../app/api/public/site-visits/route';
+import { GET as getMonthlyFrequency } from '../../app/api/public/site-visits/monthly-frequency/route';
+import { createStandardConnection } from '@/lib/database/connection-standard';
+
+type DbVisitRow = {
+  id: string;
+  date: Date;
+  salesperson: 'James' | 'Luyanda' | 'Stefan';
+  plannedMines: string[];
+  mainPurpose: string;
+  comments: string | null;
+  availability?: string;
+  createdAt?: Date;
+  updatedAt?: Date;
+};
+
+type QueryCondition = {
+  op: 'and' | 'gte' | 'lte' | 'lt' | 'eq';
+  column?: string;
+  value?: unknown;
+  conditions?: QueryCondition[];
+};
+
+type QueryRecord = {
+  type: 'list' | 'monthly';
+  where?: QueryCondition;
+  limit?: number;
+};
+
+const mockState = vi.hoisted(() => ({
+  createStandardConnection: vi.fn(),
+  generateCorrelationId: vi.fn(() => 'test-correlation-id'),
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+  listRows: [] as DbVisitRow[],
+  monthlyRows: [] as DbVisitRow[],
+  queries: [] as QueryRecord[],
+}));
+
+vi.mock('@/lib/log', () => ({
+  generateCorrelationId: mockState.generateCorrelationId,
+  logError: mockState.logError,
+  logWarn: mockState.logWarn,
+}));
+
+vi.mock('@/lib/database/connection-standard', () => ({
+  createStandardConnection: mockState.createStandardConnection,
+  sql: vi.fn(() => ({ op: 'month_expression' })),
+}));
+
+vi.mock('drizzle-orm', async () => {
+  const actual = await vi.importActual<typeof import('drizzle-orm')>('drizzle-orm');
+  const columnName = (column: any) => column?.name ?? column?.config?.name;
+
+  return {
+    ...actual,
+    and: vi.fn((...conditions: QueryCondition[]) => ({ op: 'and', conditions })),
+    asc: vi.fn((value: unknown) => ({ op: 'asc', value })),
+    count: vi.fn((value: unknown) => ({ op: 'count', value })),
+    desc: vi.fn((value: unknown) => ({ op: 'desc', value })),
+    eq: vi.fn((column: unknown, value: unknown) => ({ op: 'eq', column: columnName(column), value })),
+    gte: vi.fn((column: unknown, value: unknown) => ({ op: 'gte', column: columnName(column), value })),
+    lt: vi.fn((column: unknown, value: unknown) => ({ op: 'lt', column: columnName(column), value })),
+    lte: vi.fn((column: unknown, value: unknown) => ({ op: 'lte', column: columnName(column), value })),
+  };
+});
+
+const authorizedHeaders = { Authorization: 'Bearer expected-token' };
+
+const publicRequest = (path: string, headers: HeadersInit = authorizedHeaders) =>
+  new NextRequest(`http://localhost:3000${path}`, { headers });
+
+const parseResponse = async (response: Response) => ({
+  status: response.status,
+  body: await response.json(),
+});
+
+const visit = (
+  id: string,
+  date: string,
+  salesperson: DbVisitRow['salesperson'],
+  extra: Partial<DbVisitRow> = {}
+): DbVisitRow => ({
+  id,
+  date: new Date(`${date}T12:00:00.000Z`),
+  salesperson,
+  plannedMines: [`${id} Mine`],
+  mainPurpose: 'Quote follow-up',
+  comments: `${id} comments`,
+  availability: 'Later this morning',
+  createdAt: new Date(`${date}T13:00:00.000Z`),
+  updatedAt: new Date(`${date}T14:00:00.000Z`),
+  ...extra,
+});
+
+const compareDates = (actual: Date, expected: unknown, op: 'gte' | 'lte' | 'lt') => {
+  const actualTime = actual.getTime();
+  const expectedTime = expected instanceof Date ? expected.getTime() : new Date(String(expected)).getTime();
+
+  if (op === 'gte') return actualTime >= expectedTime;
+  if (op === 'lte') return actualTime <= expectedTime;
+  return actualTime < expectedTime;
+};
+
+const matchesCondition = (row: DbVisitRow, condition?: QueryCondition): boolean => {
+  if (!condition) return true;
+
+  if (condition.op === 'and') {
+    return (condition.conditions ?? []).every((child) => matchesCondition(row, child));
+  }
+
+  if (condition.column === 'date' && ['gte', 'lte', 'lt'].includes(condition.op)) {
+    return compareDates(row.date, condition.value, condition.op as 'gte' | 'lte' | 'lt');
+  }
+
+  if (condition.column === 'salesperson' && condition.op === 'eq') {
+    return row.salesperson === condition.value;
+  }
+
+  return true;
+};
+
+const formatMonth = (date: Date) => {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  return `${year}-${month}`;
+};
+
+const createListBuilder = () => {
+  const query: QueryRecord = { type: 'list' };
+  mockState.queries.push(query);
+
+  const builder = {
+    from: vi.fn(() => builder),
+    where: vi.fn((condition: QueryCondition) => {
+      query.where = condition;
+      return builder;
+    }),
+    orderBy: vi.fn(() => builder),
+    limit: vi.fn((limit: number) => {
+      query.limit = limit;
+      return mockState.listRows
+        .filter((row) => matchesCondition(row, query.where))
+        .sort((a, b) => b.date.getTime() - a.date.getTime())
+        .slice(0, limit);
+    }),
+  };
+
+  return builder;
+};
+
+const createMonthlyBuilder = () => {
+  const query: QueryRecord = { type: 'monthly' };
+  mockState.queries.push(query);
+
+  const builder = {
+    from: vi.fn(() => builder),
+    where: vi.fn((condition: QueryCondition) => {
+      query.where = condition;
+      return builder;
+    }),
+    groupBy: vi.fn(() => builder),
+    orderBy: vi.fn(() => {
+      const grouped = mockState.monthlyRows
+        .filter((row) => matchesCondition(row, query.where))
+        .reduce<Record<string, { month: Date; salesperson: string; visit_count: number }>>((acc, row) => {
+          const month = formatMonth(row.date);
+          const key = `${month}:${row.salesperson}`;
+          acc[key] ??= {
+            month: new Date(`${month}-01T00:00:00.000Z`),
+            salesperson: row.salesperson,
+            visit_count: 0,
+          };
+          acc[key].visit_count += 1;
+          return acc;
+        }, {});
+
+      return Object.values(grouped).sort((a, b) =>
+        formatMonth(a.month).localeCompare(formatMonth(b.month)) ||
+        a.salesperson.localeCompare(b.salesperson)
+      );
+    }),
+  };
+
+  return builder;
+};
+
+const mockDb = () => ({
+  select: vi.fn((fields: Record<string, unknown>) => {
+    if ('visit_count' in fields) {
+      return createMonthlyBuilder();
+    }
+
+    return createListBuilder();
+  }),
+});
+
+describe('Public Site Visits API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    vi.stubEnv('PUBLIC_API_TOKEN', 'expected-token');
+    mockState.listRows = [];
+    mockState.monthlyRows = [];
+    mockState.queries = [];
+    vi.mocked(createStandardConnection).mockReturnValue({ db: mockDb() } as any);
+  });
+
+  describe('authentication', () => {
+    it('rejects a missing authorization header', async () => {
+      const response = await getPublicSiteVisits(publicRequest('/api/public/site-visits', {}));
+
+      await expect(parseResponse(response)).resolves.toEqual({
+        status: 401,
+        body: { ok: false, error: 'Unauthorized' },
+      });
+      expect(createStandardConnection).not.toHaveBeenCalled();
+    });
+
+    it('rejects a wrong bearer token', async () => {
+      const response = await getMonthlyFrequency(
+        publicRequest('/api/public/site-visits/monthly-frequency', { Authorization: 'Bearer wrong-token' })
+      );
+
+      await expect(parseResponse(response)).resolves.toEqual({
+        status: 401,
+        body: { ok: false, error: 'Unauthorized' },
+      });
+      expect(createStandardConnection).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /api/public/site-visits', () => {
+    beforeEach(() => {
+      mockState.listRows = [
+        visit('visit-1', '2025-01-10', 'James'),
+        visit('visit-2', '2025-02-15', 'Luyanda'),
+        visit('visit-3', '2025-03-20', 'James'),
+        visit('visit-4', '2025-04-05', 'Stefan'),
+      ];
+    });
+
+    it.each([
+      ['from', '?from=2025-02-01', ['visit-4', 'visit-3', 'visit-2']],
+      ['to', '?to=2025-02-28', ['visit-2', 'visit-1']],
+      ['salesperson', '?salesperson=James', ['visit-3', 'visit-1']],
+      ['limit', '?limit=2', ['visit-4', 'visit-3']],
+    ])('returns 200 with the %s filter', async (_filter, query, expectedIds) => {
+      const response = await getPublicSiteVisits(publicRequest(`/api/public/site-visits${query}`));
+      const result = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(result.ok).toBe(true);
+      expect(result.data.map((row: { id: string }) => row.id)).toEqual(expectedIds);
+      expect(result.count).toBe(expectedIds.length);
+    });
+
+    it('returns 200 with combined filters', async () => {
+      const response = await getPublicSiteVisits(
+        publicRequest('/api/public/site-visits?from=2025-02-01&to=2025-03-31&salesperson=James&limit=1')
+      );
+      const result = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(result).toMatchObject({ ok: true, count: 1 });
+      expect(result.data.map((row: { id: string }) => row.id)).toEqual(['visit-3']);
+      expect(mockState.queries[0].limit).toBe(1);
+    });
+
+    it('returns only public fields and excludes internal fields', async () => {
+      mockState.listRows = [visit('visit-public', '2025-02-15', 'James')];
+
+      const response = await getPublicSiteVisits(publicRequest('/api/public/site-visits'));
+      const result = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(Object.keys(result.data[0]).sort()).toEqual([
+        'comments',
+        'date',
+        'id',
+        'main_purpose',
+        'planned_mines',
+        'salesperson',
+      ]);
+      expect(result.data[0]).not.toHaveProperty('availability');
+      expect(result.data[0]).not.toHaveProperty('created_at');
+      expect(result.data[0]).not.toHaveProperty('updated_at');
+    });
+  });
+
+  describe('GET /api/public/site-visits/monthly-frequency', () => {
+    it('groups monthly visit counts across 3 months and 2 salespersons', async () => {
+      mockState.monthlyRows = [
+        visit('jan-james-1', '2025-01-05', 'James'),
+        visit('jan-james-2', '2025-01-20', 'James'),
+        visit('jan-luyanda-1', '2025-01-22', 'Luyanda'),
+        visit('feb-james-1', '2025-02-03', 'James'),
+        visit('feb-luyanda-1', '2025-02-16', 'Luyanda'),
+        visit('mar-james-1', '2025-03-11', 'James'),
+      ];
+
+      const response = await getMonthlyFrequency(
+        publicRequest('/api/public/site-visits/monthly-frequency?from=2025-01&to=2025-03')
+      );
+      const result = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(result).toEqual({
+        ok: true,
+        data: [
+          { month: '2025-01', salesperson: 'James', visit_count: 2 },
+          { month: '2025-01', salesperson: 'Luyanda', visit_count: 1 },
+          { month: '2025-02', salesperson: 'James', visit_count: 1 },
+          { month: '2025-02', salesperson: 'Luyanda', visit_count: 1 },
+          { month: '2025-03', salesperson: 'James', visit_count: 1 },
+        ],
+      });
+      expect(result.data.every((row: { month: string }) => /^\d{4}-\d{2}$/.test(row.month))).toBe(true);
+    });
+
+    it('uses the last 12 months as the default range when params are omitted', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-13T12:00:00.000Z'));
+      mockState.monthlyRows = [
+        visit('outside-range', '2025-05-31', 'James'),
+        visit('range-start', '2025-06-01', 'James'),
+        visit('range-end', '2026-05-13', 'Luyanda'),
+      ];
+
+      const response = await getMonthlyFrequency(
+        publicRequest('/api/public/site-visits/monthly-frequency')
+      );
+      const result = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(result).toEqual({
+        ok: true,
+        data: [
+          { month: '2025-06', salesperson: 'James', visit_count: 1 },
+          { month: '2026-05', salesperson: 'Luyanda', visit_count: 1 },
+        ],
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new authenticated public REST API under `/api/public/site-visits` to expose site-visit data for external consumers.

## What's Added

- **GET /api/public/site-visits** – Returns raw site-visit records
- **GET /api/public/site-visits/monthly-frequency** – Returns monthly visit frequency aggregation
- **lib/auth/public-api-auth.ts** – Bearer-token authentication helper
- **Tests** – 15 new tests added (583 total, 0 failures)
- **Documentation** – Public API access documented

## Authentication

All endpoints require a `Bearer` token passed in the `Authorization` header. The token is validated against the `PUBLIC_API_TOKEN` environment variable via `lib/auth/public-api-auth.ts`.

## Intended Consumer

This API is built for the **Pipedrive MCP server** to enable programmatic access to site-visit data.

## ⚠️ Pre-Deployment Note

The `PUBLIC_API_TOKEN` environment variable **must be set in Vercel** before these endpoints go live. Without it, authenticated requests will be rejected.